### PR TITLE
Fixed inconsistency in usage of TRUE vs. true in FlightController Plugin

### DIFF
--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
@@ -192,7 +192,7 @@ void FlightControllerPlugin::Load(physics::WorldPtr _world, sdf::ElementPtr _sdf
 
   this->cmdPub = this->nodeHandle->Advertise<cmd_msgs::msgs::MotorCommand>(this->cmdPubTopic);
   // Force pause because we drive the simulation steps
-  this->world->SetPaused(TRUE);
+  this->world->SetPaused(true);
 
 
   this->callbackLoopThread = boost::thread( boost::bind( &FlightControllerPlugin::LoopThread, this) );


### PR DESCRIPTION
Addresses #39 

Replaced the use of `TRUE` with `true` in the FlightControllerPlugin. This fixes build issues which are encountered in some environments.

