### PR TITLE
Distance Sensor Capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CMakeCache.txt
 gymfc.json
 .idea
 env/
+gymfc/envs/assets/gazebo/plugins/.DS_Store

--- a/gymfc/envs/assets/gazebo/plugins/CMakeLists.txt
+++ b/gymfc/envs/assets/gazebo/plugins/CMakeLists.txt
@@ -51,6 +51,7 @@ set(sensor_msgs
   msgs/EscSensor.proto
   msgs/State.proto
   msgs/Action.proto
+  msgs/DistanceSensor.proto
   ${PROTOBUF_IMPORT_DIRS}/vector3d.proto
   ${PROTOBUF_IMPORT_DIRS}/quaternion.proto
   )

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
@@ -457,6 +457,10 @@ void FlightControllerPlugin::ParseDigitalTwinSDF()
     {
       this->supportedSensors.push_back(ESC);
     }
+    else if (boost::iequals(type, "distance"))
+    {
+      this->supportedSensors.push_back(DISTANCE);
+    }
     else if (boost::iequals(type, "battery"))
     {
       this->supportedSensors.push_back(BATTERY);
@@ -696,6 +700,9 @@ void FlightControllerPlugin::CalculateCallbackCount()
         break;
       case ESC:
         this->numSensorCallbacks += this->numActuators;
+        break;
+      case DISTANCE:
+        this->numSensorCallbacks += 1;
         break;
     }
   }

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
@@ -62,7 +62,7 @@ typedef SSIZE_T ssize_t;
 #include "EscSensor.pb.h"
 #include "Imu.pb.h"
 
-#include "DistanceSensor.pb.h" distance_sensor
+#include "DistanceSensor.pb.h" //distance_sensor
 
 
 
@@ -812,6 +812,4 @@ void FlightControllerPlugin::SendState() const
            buf.size(), 0,
 		   (struct sockaddr *)&this->remaddr, this->remaddrlen); 
 }
-
-
 

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp
@@ -192,7 +192,7 @@ void FlightControllerPlugin::Load(physics::WorldPtr _world, sdf::ElementPtr _sdf
         break;
       case DISTANCE:  //distance sensor 
       //Each direction will have a different index, only one for now
-        this->distanceSub = this->nodeHandle->Subscribe<sensor_msgs::msgs::DistanceSensor>(this->distanceSubTopic, &FlightControllerPlugin::ImuCallback, this);
+        this->distanceSub = this->nodeHandle->Subscribe<sensor_msgs::msgs::DistanceSensor>(this->distanceSubTopic, &FlightControllerPlugin::DistanceSensorCallback, this);
         break;
     }
   }

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
@@ -33,6 +33,7 @@
 #include "Imu.pb.h"
 #include "State.pb.h"
 #include "Action.pb.h"
+#include "DistanceSensor.pb.h"
 
 #define ENV_SITL_PORT "GYMFC_SITL_PORT"
 #define ENV_DIGITAL_TWIN_SDF "GYMFC_DIGITAL_TWIN_SDF"
@@ -60,7 +61,8 @@ namespace gazebo
   enum Sensors {
     IMU,
     ESC,
-    BATTERY
+    BATTERY,
+    DISTANCE
   };
 
 class FlightControllerPlugin : public WorldPlugin

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
@@ -174,6 +174,7 @@ class FlightControllerPlugin : public WorldPlugin
   private: std::string cmdPubTopic;
   private: std::string imuSubTopic;
   private: std::string escSubTopic;
+  private: std::string distanceSubTopic;
   private: transport::NodePtr nodeHandle;
   // Now define the communication channels with the digital twin
   // The architecure treats this world plugin as the flight controller

--- a/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
+++ b/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.hh
@@ -118,6 +118,9 @@ class FlightControllerPlugin : public WorldPlugin
 
   /// \brief Callback from the digital twin to recieve IMU values
   private: void ImuCallback(ImuPtr &_imu);
+  
+   /// \brief Callback from the digital twin to recieve Distance Sensor values
+  private: void DistanceSensorCallback(DistanceSensorPtr &_distanceSensor);
 
   private: void CalculateCallbackCount();
   private: void ResetCallbackCount();

--- a/gymfc/envs/assets/gazebo/plugins/msgs/DistanceSensor.proto
+++ b/gymfc/envs/assets/gazebo/plugins/msgs/DistanceSensor.proto
@@ -3,5 +3,5 @@ package sensor_msgs.msgs;
 
 message DistanceSensor
 {
-  required float    distance  = 0;
+  required float    distance  = 13;
 }

--- a/gymfc/envs/assets/gazebo/plugins/msgs/DistanceSensor.proto
+++ b/gymfc/envs/assets/gazebo/plugins/msgs/DistanceSensor.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+package sensor_msgs.msgs;
+
+message DistanceSensor
+{
+  required float    distance  = 0;
+}

--- a/gymfc/envs/assets/gazebo/plugins/msgs/State.proto
+++ b/gymfc/envs/assets/gazebo/plugins/msgs/State.proto
@@ -24,7 +24,7 @@ message State
   optional float  vbat_voltage = 11;
   optional float  vbat_current = 12;
 
-  // Distance Sensor
+  // Distance Sensor. Units in meters. Different indices may indicate different directions
   repeated float  distance_sensor = 13 [packed=true];
 
 

--- a/gymfc/envs/assets/gazebo/plugins/msgs/State.proto
+++ b/gymfc/envs/assets/gazebo/plugins/msgs/State.proto
@@ -24,15 +24,20 @@ message State
   optional float  vbat_voltage = 11;
   optional float  vbat_current = 12;
 
+  // Distance Sensor
+  repeated float  distance_sensor = 13 [packed=true];
+
+
+
   // Placeholder for additional codes
   enum StatusCode {
     OK = 0;
     ERROR = 1;
   }
 
-  required StatusCode status_code = 13; 
+  required StatusCode status_code = 14; 
 
   // Force applied to the ball joint
-  repeated float force = 14 [packed=true];
+  repeated float force = 15 [packed=true];
 
 }


### PR DESCRIPTION
### Description of the Change

Before we implement a new distance sensor into the aircraft we first have to work on GymFC in order to have those capabilities.

-Distance Sensor Message included in **State.proto**
-Distance Sensor added in **FlightControllerPlugin.cpp**





Distance Sensor included in State.proto
Used IMU as an example in FlightControllerPlugin.cpp to add distance sensor 
DistanceSensor.proto added


### Verification Process
Running **build_plugin.sh** error

```
[ 87%] Building CXX object CMakeFiles/FlightControllerPlugin.dir/FlightControllerPlugin.cpp.o
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp: In member function ‘virtual void gazebo::FlightControllerPlugin::Load(gazebo::physics::WorldPtr, sdf::ElementPtr)’:
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp:195:98: error: ‘class gazebo::FlightControllerPlugin’ has no member named ‘distanceSubTopic’; did you mean ‘distanceSub’?
         this->distanceSub = this->nodeHandle->Subscribe<sensor_msgs::msgs::DistanceSensor>(this->distanceSubTopic, &FlightControllerPlugin::DistanceSensorCallback, this);
                                                                                                  ^~~~~~~~~~~~~~~~
                                                                                                  distanceSub
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp:195:141: error: ‘DistanceSensorCallback’ is not a member of ‘gazebo::FlightControllerPlugin’
         this->distanceSub = this->nodeHandle->Subscribe<sensor_msgs::msgs::DistanceSensor>(this->distanceSubTopic, &FlightControllerPlugin::DistanceSensorCallback, this);
                                                                                                                                             ^~~~~~~~~~~~~~~~~~~~~~
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp: In member function ‘void gazebo::FlightControllerPlugin::InitState()’:
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp:290:17: error: ‘class gymfc::msgs::State’ has no member named ‘add_distance’; did you mean ‘add_force’?
     this->state.add_distance(0);
                 ^~~~~~~~~~~~
                 add_force
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp: At global scope:
/home/xabi/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins/FlightControllerPlugin.cpp:311:87: error: no ‘void gazebo::FlightControllerPlugin::DistanceSensorCallback(gazebo::DistanceSensorPtr&)’ member function declared in class ‘gazebo::FlightControllerPlugin’
 void FlightControllerPlugin::DistanceSensorCallback(DistanceSensorPtr &_distanceSensor)
                                                                                       ^
CMakeFiles/FlightControllerPlugin.dir/build.make:62: recipe for target 'CMakeFiles/FlightControllerPlugin.dir/FlightControllerPlugin.cpp.o' failed
make[2]: *** [CMakeFiles/FlightControllerPlugin.dir/FlightControllerPlugin.cpp.o] Error 1
CMakeFiles/Makefile2:68: recipe for target 'CMakeFiles/FlightControllerPlugin.dir/all' failed
make[1]: *** [CMakeFiles/FlightControllerPlugin.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
(env) xabi@xabi-VirtualBox:~/projects/gymfc-xabi/gymfc/envs/assets/gazebo/plugins$ 

```